### PR TITLE
Skip GTK4 building in CI in case of cache hit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Configure GTK4 cache (Windows)
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
+        id: cache
         with:
           path: C:\gtk-build
           key: ${{ runner.os }}-gtk4
@@ -67,7 +68,7 @@ jobs:
         run: |
           Move-Item "C:\Program Files\Git\usr\bin" "C:\Program Files\Git\usr\notbin"
           Move-Item "C:\Program Files\Git\bin" "C:\Program Files\Git\notbin"
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
 
       - name: Install GTK4 (Windows)
         run: |
@@ -86,14 +87,14 @@ jobs:
             Get-Content actual-dlls.log
             Throw "Actual DLLs do not match expected"
           }
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
 
       # TODO: This is a workaround for https://github.com/wingtk/gvsbuild/issues/984, remove once fixed upstream
       - name: Restore git binary (Windows)
         run: |
           Move-Item "C:\Program Files\Git\usr\notbin" "C:\Program Files\Git\usr\bin"
           Move-Item "C:\Program Files\Git\notbin" "C:\Program Files\Git\bin"
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
 
       # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
       # TODO: on macOS, the consensus/domain runtime build is not compatible with LLVM 15.0.7 and

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
         id: cache
         with:
-          path: C:\gtk-build
+          path: C:\gtk-build\gtk\x64\release
           key: ${{ runner.os }}-gtk4
         if: runner.os == 'Windows'
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
         id: cache
         with:
-          path: C:\gtk-build
+          path: C:\gtk-build\gtk\x64\release
           key: ${{ runner.os }}-gtk4
         if: runner.os == 'Windows'
 
@@ -180,7 +180,7 @@ jobs:
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
         id: cache
         with:
-          path: C:\gtk-build
+          path: C:\gtk-build\gtk\x64\release
           key: ${{ runner.os }}-gtk4
         if: runner.os == 'Windows'
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,6 +74,7 @@ jobs:
 
       - name: Configure GTK4 cache (Windows)
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
+        id: cache
         with:
           path: C:\gtk-build
           key: ${{ runner.os }}-gtk4
@@ -84,7 +85,7 @@ jobs:
         run: |
           Move-Item "C:\Program Files\Git\usr\bin" "C:\Program Files\Git\usr\notbin"
           Move-Item "C:\Program Files\Git\bin" "C:\Program Files\Git\notbin"
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
 
       - name: Install GTK4 (Windows)
         run: |
@@ -103,14 +104,14 @@ jobs:
             Get-Content actual-dlls.log
             Throw "Actual DLLs do not match expected"
           }
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
 
       # TODO: This is a workaround for https://github.com/wingtk/gvsbuild/issues/984, remove once fixed upstream
       - name: Restore git binary (Windows)
         run: |
           Move-Item "C:\Program Files\Git\usr\notbin" "C:\Program Files\Git\usr\bin"
           Move-Item "C:\Program Files\Git\notbin" "C:\Program Files\Git\bin"
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
 
       # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
       # TODO: on macOS, the consensus/domain runtime build is not compatible with LLVM 15.0.7 and
@@ -177,6 +178,7 @@ jobs:
 
       - name: Configure GTK4 cache (Windows)
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # @v3.3.2
+        id: cache
         with:
           path: C:\gtk-build
           key: ${{ runner.os }}-gtk4
@@ -187,7 +189,7 @@ jobs:
         run: |
           Move-Item "C:\Program Files\Git\usr\bin" "C:\Program Files\Git\usr\notbin"
           Move-Item "C:\Program Files\Git\bin" "C:\Program Files\Git\notbin"
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
 
       - name: Install GTK4 (Windows)
         run: |
@@ -206,14 +208,14 @@ jobs:
             Get-Content actual-dlls.log
             Throw "Actual DLLs do not match expected"
           }
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
 
       # TODO: This is a workaround for https://github.com/wingtk/gvsbuild/issues/984, remove once fixed upstream
       - name: Restore git binary (Windows)
         run: |
           Move-Item "C:\Program Files\Git\usr\notbin" "C:\Program Files\Git\usr\bin"
           Move-Item "C:\Program Files\Git\notbin" "C:\Program Files\Git\bin"
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
 
       # On macOS, we need a proper Clang version, not Apple's custom version without wasm32 support
       # TODO: on macOS, the consensus/domain runtime build is not compatible with LLVM 15.0.7 and


### PR DESCRIPTION
Will improve CI time by a few minutes