### PR TITLE
Upgrade Subspace to the upcoming release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -2589,7 +2589,7 @@ dependencies = [
 [[package]]
 name = "domain-block-preprocessor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6753,7 +6753,7 @@ dependencies = [
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6827,7 +6827,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -6851,7 +6851,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6870,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6884,7 +6884,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6896,7 +6896,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6909,7 +6909,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6967,7 +6967,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7023,7 +7023,7 @@ dependencies = [
 [[package]]
 name = "pallet-transporter"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -7080,9 +7080,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e9ab494af9e6e813c72170f0d3c1de1500990d62c97cc05cc7576f91aa402f"
+checksum = "592a28a24b09c9dc20ac8afaa6839abc417c720afe42c12e1e4a9d6aa2508d2e"
 dependencies = [
  "blake2",
  "crc32fast",
@@ -7096,6 +7096,7 @@ dependencies = [
  "rand 0.8.5",
  "siphasher",
  "snap",
+ "winapi",
 ]
 
 [[package]]
@@ -8620,7 +8621,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "async-trait",
  "futures",
@@ -8660,7 +8661,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -8977,7 +8978,7 @@ dependencies = [
 [[package]]
 name = "sc-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "atomic",
  "core_affinity",
@@ -9197,7 +9198,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-block-relay"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -9222,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -10033,7 +10034,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "async-trait",
  "log",
@@ -10148,7 +10149,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -10157,7 +10158,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "blake2",
  "domain-runtime-primitives",
@@ -10188,7 +10189,7 @@ dependencies = [
 [[package]]
 name = "sp-domains-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "domain-block-preprocessor",
  "domain-runtime-primitives",
@@ -10220,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "sp-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10312,7 +10313,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "frame-support",
  "hash-db",
@@ -10342,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -10654,7 +10655,7 @@ dependencies = [
 
 [[package]]
 name = "space-acres"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -10866,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "parity-scale-codec",
  "rayon",
@@ -10879,7 +10880,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "blake3",
  "derive_more",
@@ -10902,7 +10903,7 @@ dependencies = [
 [[package]]
 name = "subspace-erasure-coding"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "kzg",
  "rust-kzg-blst",
@@ -10912,7 +10913,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "anyhow",
  "async-lock 2.8.0",
@@ -10970,7 +10971,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "async-lock 2.8.0",
  "async-trait",
@@ -11000,7 +11001,7 @@ dependencies = [
 [[package]]
 name = "subspace-metrics"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "actix-web",
  "parking_lot 0.12.1",
@@ -11012,7 +11013,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "actix-web",
  "async-mutex",
@@ -11051,7 +11052,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-space"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "chacha20",
  "derive_more",
@@ -11064,7 +11065,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "aes 0.8.3",
  "subspace-core-primitives",
@@ -11074,7 +11075,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "hex",
  "serde",
@@ -11086,7 +11087,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -11138,7 +11139,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "pallet-transaction-payment",
  "serde",
@@ -11151,7 +11152,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "async-trait",
  "atomic",
@@ -11221,7 +11222,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=196a0086f4240541cf3f48ee26db1c3251128d5a#196a0086f4240541cf3f48ee26db1c3251128d5a"
+source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -11984,7 +11985,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "space-acres"
 description = "Space Acres is an opinionated unofficial GUI application for farming on Subspace Network"
 license = "0BSD"
-version = "0.0.14"
+version = "0.0.15"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 repository = "https://github.com/nazar-pc/space-acres"
 edition = "2021"
@@ -62,23 +62,23 @@ sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b
 sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
 sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
 sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "196a0086f4240541cf3f48ee26db1c3251128d5a" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
 serde = { version = "1.0.193", features = ["derive"]}
 serde_json = "1.0.108"
 sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "196a0086f4240541cf3f48ee26db1c3251128d5a" }
-sp-domains-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "196a0086f4240541cf3f48ee26db1c3251128d5a" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
+sp-domains-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
 sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "196a0086f4240541cf3f48ee26db1c3251128d5a" }
-subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "196a0086f4240541cf3f48ee26db1c3251128d5a" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "196a0086f4240541cf3f48ee26db1c3251128d5a", default-features = false }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "196a0086f4240541cf3f48ee26db1c3251128d5a" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "196a0086f4240541cf3f48ee26db1c3251128d5a" }
-subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "196a0086f4240541cf3f48ee26db1c3251128d5a" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "196a0086f4240541cf3f48ee26db1c3251128d5a" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "196a0086f4240541cf3f48ee26db1c3251128d5a" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "196a0086f4240541cf3f48ee26db1c3251128d5a" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "196a0086f4240541cf3f48ee26db1c3251128d5a" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
+subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce", default-features = false }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
+subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
 supports-color = "2.0.0"
 thiserror = "1.0.50"
 tokio = { version = "1.34.0", features = ["fs", "time"] }


### PR DESCRIPTION
This also includes `parity-db` update and should fix https://github.com/nazar-pc/space-acres/issues/56 (though GTK memory leak is still present and will be handled separately once new GTK release is out)