### PR TITLE
Sectors visualization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8043,7 +8043,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 [[package]]
 name = "relm4"
 version = "0.7.0-beta.2"
-source = "git+https://github.com/Relm4/Relm4?rev=f216c7f5ba1324413cb16e45c37e0b9297473ec2#f216c7f5ba1324413cb16e45c37e0b9297473ec2"
+source = "git+https://github.com/Relm4/Relm4?rev=e189eee06b887470e0fd65cbaf6d7c0161bed5ea#e189eee06b887470e0fd65cbaf6d7c0161bed5ea"
 dependencies = [
  "async-trait",
  "flume",
@@ -8059,7 +8059,7 @@ dependencies = [
 [[package]]
 name = "relm4-components"
 version = "0.7.0-beta.2"
-source = "git+https://github.com/Relm4/Relm4?rev=f216c7f5ba1324413cb16e45c37e0b9297473ec2#f216c7f5ba1324413cb16e45c37e0b9297473ec2"
+source = "git+https://github.com/Relm4/Relm4?rev=e189eee06b887470e0fd65cbaf6d7c0161bed5ea#e189eee06b887470e0fd65cbaf6d7c0161bed5ea"
 dependencies = [
  "once_cell",
  "relm4",
@@ -8079,7 +8079,7 @@ dependencies = [
 [[package]]
 name = "relm4-macros"
 version = "0.7.0-beta.2"
-source = "git+https://github.com/Relm4/Relm4?rev=f216c7f5ba1324413cb16e45c37e0b9297473ec2#f216c7f5ba1324413cb16e45c37e0b9297473ec2"
+source = "git+https://github.com/Relm4/Relm4?rev=e189eee06b887470e0fd65cbaf6d7c0161bed5ea#e189eee06b887470e0fd65cbaf6d7c0161bed5ea"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -2589,7 +2589,7 @@ dependencies = [
 [[package]]
 name = "domain-block-preprocessor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6753,7 +6753,7 @@ dependencies = [
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6827,7 +6827,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -6851,7 +6851,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6870,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6884,7 +6884,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6896,7 +6896,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6909,7 +6909,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6967,7 +6967,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7023,7 +7023,7 @@ dependencies = [
 [[package]]
 name = "pallet-transporter"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -8661,7 +8661,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "async-trait",
  "futures",
@@ -8701,7 +8701,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "sc-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "atomic",
  "core_affinity",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-block-relay"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -10074,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "async-trait",
  "log",
@@ -10189,7 +10189,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -10198,7 +10198,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "blake2",
  "domain-runtime-primitives",
@@ -10229,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "sp-domains-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "domain-block-preprocessor",
  "domain-runtime-primitives",
@@ -10261,7 +10261,7 @@ dependencies = [
 [[package]]
 name = "sp-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10353,7 +10353,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "frame-support",
  "hash-db",
@@ -10383,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -10909,7 +10909,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "parity-scale-codec",
  "rayon",
@@ -10922,7 +10922,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "blake3",
  "derive_more",
@@ -10945,7 +10945,7 @@ dependencies = [
 [[package]]
 name = "subspace-erasure-coding"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "kzg",
  "rust-kzg-blst",
@@ -10955,7 +10955,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "anyhow",
  "async-lock 2.8.0",
@@ -11013,7 +11013,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "async-lock 2.8.0",
  "async-trait",
@@ -11043,7 +11043,7 @@ dependencies = [
 [[package]]
 name = "subspace-metrics"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "actix-web",
  "parking_lot 0.12.1",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "actix-web",
  "async-mutex",
@@ -11094,7 +11094,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-space"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "chacha20",
  "derive_more",
@@ -11107,7 +11107,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "aes 0.8.3",
  "subspace-core-primitives",
@@ -11117,7 +11117,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "hex",
  "serde",
@@ -11129,7 +11129,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -11181,7 +11181,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "pallet-transaction-payment",
  "serde",
@@ -11194,7 +11194,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "async-trait",
  "atomic",
@@ -11264,7 +11264,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=91829422a9c4cc5e8576b864bfc4ab83b752a8ce#91829422a9c4cc5e8576b864bfc4ab83b752a8ce"
+source = "git+https://github.com/subspace/subspace?rev=7ac659062299f1911011aee5f1eb431805cf2883#7ac659062299f1911011aee5f1eb431805cf2883"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10695,7 +10695,7 @@ dependencies = [
 
 [[package]]
 name = "space-acres"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,24 +63,24 @@ sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b
 sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
 sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
 sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "7ac659062299f1911011aee5f1eb431805cf2883" }
 semver = "1.0.21"
 serde = { version = "1.0.194", features = ["derive"]}
 serde_json = "1.0.111"
 sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
-sp-domains-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "7ac659062299f1911011aee5f1eb431805cf2883" }
+sp-domains-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "7ac659062299f1911011aee5f1eb431805cf2883" }
 sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
-subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce", default-features = false }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
-subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "91829422a9c4cc5e8576b864bfc4ab83b752a8ce" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "7ac659062299f1911011aee5f1eb431805cf2883" }
+subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "7ac659062299f1911011aee5f1eb431805cf2883" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "7ac659062299f1911011aee5f1eb431805cf2883", default-features = false }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "7ac659062299f1911011aee5f1eb431805cf2883" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "7ac659062299f1911011aee5f1eb431805cf2883" }
+subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "7ac659062299f1911011aee5f1eb431805cf2883" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "7ac659062299f1911011aee5f1eb431805cf2883" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "7ac659062299f1911011aee5f1eb431805cf2883" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "7ac659062299f1911011aee5f1eb431805cf2883" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "7ac659062299f1911011aee5f1eb431805cf2883" }
 supports-color = "2.0.0"
 thiserror = "1.0.50"
 tokio = { version = "1.34.0", features = ["fs", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,9 +52,9 @@ names = "0.14.0"
 pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
 parity-scale-codec = "3.6.9"
 parking_lot = "0.12.1"
-relm4 = { version = "0.7.0-beta.2", git = "https://github.com/Relm4/Relm4", rev = "f216c7f5ba1324413cb16e45c37e0b9297473ec2" }
+relm4 = { version = "0.7.0-beta.2", git = "https://github.com/Relm4/Relm4", rev = "e189eee06b887470e0fd65cbaf6d7c0161bed5ea" }
 relm4-icons = { version = "0.7.0-alpha.2", features = ["checkmark", "cross", "menu-large", "size-horizontally", "ssd", "wallet2"] }
-relm4-components = { version = "0.7.0-beta.2", git = "https://github.com/Relm4/Relm4", rev = "f216c7f5ba1324413cb16e45c37e0b9297473ec2", default-features = false }
+relm4-components = { version = "0.7.0-beta.2", git = "https://github.com/Relm4/Relm4", rev = "e189eee06b887470e0fd65cbaf6d7c0161bed5ea", default-features = false }
 reqwest = { version = "0.11.23", default-features = false, features = ["json", "rustls-tls"] }
 sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
 sc-client-db = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "space-acres"
 description = "Space Acres is an opinionated unofficial GUI application for farming on Subspace Network"
 license = "0BSD"
-version = "0.0.17"
+version = "0.0.18"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 repository = "https://github.com/nazar-pc/space-acres"
 edition = "2021"

--- a/res/app.css
+++ b/res/app.css
@@ -18,3 +18,64 @@ progressbar progress {
 .error-label {
     color: #ff3800;
 }
+
+farm-sectors > child {
+    padding: 0;
+}
+
+farm-sector {
+    animation-iteration-count: infinite;
+    animation-direction: alternate;
+    background-color: #727272;
+    min-width: 5px;
+    min-height: 5px;
+    margin: 1px;
+}
+
+farm-sector.plotted {
+    background-color: #9fc4ff;
+}
+
+farm-sector.about-to-expire {
+    background-color: #ffd678;
+}
+
+farm-sector.expired {
+    background-color: #ff877c;
+}
+
+@keyframes animate-downloading {
+    to {
+        background-color: #499249;
+    }
+}
+
+farm-sector.downloading {
+    animation-duration: 1s;
+    animation-name: animate-downloading;
+}
+
+@keyframes animate-encoding {
+    to {
+        background-color: #ff5365;
+    }
+}
+
+farm-sector.encoding {
+    animation-duration: 0.2s;
+    animation-name: animate-encoding;
+}
+
+@keyframes animate-writing {
+    from {
+        background-color: #727272;
+    }
+    to {
+        background-color: #9fc4ff;
+    }
+}
+
+farm-sector.writing {
+    animation-duration: 1s;
+    animation-name: animate-writing;
+}

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -3,5 +3,3 @@ use std::sync::Arc;
 
 pub(super) type HandlerFn<A> = Arc<dyn Fn(&A) + Send + Sync + 'static>;
 pub(super) type Handler<A> = Bag<HandlerFn<A>, A>;
-pub(super) type Handler2Fn<A, B> = Arc<dyn Fn(&A, &B) + Send + Sync + 'static>;
-pub(super) type Handler2<A, B> = Bag<Handler2Fn<A, B>, A, B>;

--- a/src/frontend/configuration.rs
+++ b/src/frontend/configuration.rs
@@ -299,7 +299,7 @@ impl Component for ConfigurationView {
 
     fn init(
         parent_root: Self::Init,
-        root: &Self::Root,
+        root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         let open_dialog = OpenDialog::builder()

--- a/src/frontend/loading.rs
+++ b/src/frontend/loading.rs
@@ -41,7 +41,7 @@ impl Component for LoadingView {
 
     fn init(
         _init: Self::Init,
-        _root: &Self::Root,
+        _root: Self::Root,
         _sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         let model = Self {

--- a/src/frontend/new_version.rs
+++ b/src/frontend/new_version.rs
@@ -68,7 +68,7 @@ impl Component for NewVersion {
 
     fn init(
         _init: Self::Init,
-        _root: &Self::Root,
+        _root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         let model = Self { new_version: None };

--- a/src/frontend/running.rs
+++ b/src/frontend/running.rs
@@ -1,16 +1,15 @@
 mod farm;
 
 use crate::backend::config::RawConfig;
-use crate::backend::farmer::{PlottingKind, PlottingState};
+use crate::backend::farmer::{FarmerNotification, InitialFarmState};
 use crate::backend::node::{ChainInfo, SyncKind, SyncState};
-use crate::backend::{FarmerNotification, NodeNotification};
+use crate::backend::NodeNotification;
 use crate::frontend::running::farm::{FarmWidget, FarmWidgetInit, FarmWidgetInput};
 use gtk::prelude::*;
 use relm4::factory::FactoryHashMap;
 use relm4::prelude::*;
 use subspace_core_primitives::BlockNumber;
 use subspace_runtime_primitives::{Balance, SSC};
-use tracing::warn;
 
 /// Maximum blocks to store in the import queue.
 // HACK: This constant comes from Substrate's sync, but it is not public in there
@@ -21,7 +20,7 @@ pub enum RunningInput {
     Initialize {
         best_block_number: BlockNumber,
         reward_address_balance: Balance,
-        initial_plotting_states: Vec<PlottingState>,
+        initial_farm_states: Vec<InitialFarmState>,
         farm_during_initial_plotting: bool,
         raw_config: RawConfig,
         chain_info: ChainInfo,
@@ -40,9 +39,6 @@ struct NodeState {
 struct FarmerState {
     initial_reward_address_balance: Balance,
     reward_address_balance: Balance,
-    /// One entry per farm
-    plotting_state: Vec<PlottingState>,
-    farm_during_initial_plotting: bool,
     piece_cache_sync_progress: f32,
     reward_address: String,
 }
@@ -51,7 +47,7 @@ struct FarmerState {
 pub struct RunningView {
     node_state: NodeState,
     farmer_state: FarmerState,
-    farms: FactoryHashMap<usize, FarmWidget>,
+    farms: FactoryHashMap<u8, FarmWidget>,
     chain_info: ChainInfo,
 }
 
@@ -148,135 +144,95 @@ impl Component for RunningView {
             gtk::Box {
                 set_orientation: gtk::Orientation::Vertical,
                 set_spacing: 10,
-                set_valign: gtk::Align::Start,
 
-                gtk::Label {
-                    add_css_class: "heading",
-                    set_halign: gtk::Align::Start,
-                    set_label: "Farmer",
+                gtk::Box {
+                    gtk::Label {
+                        add_css_class: "heading",
+                        set_halign: gtk::Align::Start,
+                        set_label: "Farmer",
+                    },
+                    gtk::Box {
+                        set_halign: gtk::Align::End,
+                        set_hexpand: true,
+
+                        gtk::LinkButton {
+                            remove_css_class: "link",
+                            set_tooltip: "Total account balance and coins farmed since application started, click to see details in Astral",
+                            #[watch]
+                            // TODO: Would be great to have `gemini-3g` in chain spec, but it is
+                            //  not available in there in clean form
+                            set_uri: &format!(
+                                "https://explorer.subspace.network/#/{}/consensus/accounts/{}",
+                                model.chain_info.protocol_id.strip_prefix("subspace-").unwrap_or(&model.chain_info.protocol_id),
+                                model.farmer_state.reward_address
+                            ),
+                            set_use_underline: false,
+
+                            gtk::Label {
+                                #[watch]
+                                set_label: &{
+                                    let current_balance = model.farmer_state.reward_address_balance;
+                                    let balance_increase = model.farmer_state.reward_address_balance - model.farmer_state.initial_reward_address_balance;
+                                    let current_balance = (current_balance / (SSC / 100)) as f32 / 100.0;
+                                    let balance_increase = (balance_increase / (SSC / 100)) as f32 / 100.0;
+                                    let token_symbol = &model.chain_info.token_symbol;
+
+                                    format!(
+                                        "{current_balance:.2}<span color=\"#3bbf2c\"><sup>+{balance_increase:.2}</sup></span> {token_symbol}"
+                                    )
+                                },
+                                set_use_markup: true,
+                            },
+                        }
+                    },
                 },
 
-                // TODO: Render all farms, not just the first one
-                // TODO: Match only because `if let Some(x) = y` is not yet supported here: https://github.com/Relm4/Relm4/issues/582
-                #[transition = "SlideUpDown"]
-                if model.farmer_state.piece_cache_sync_progress < 100.0 {
+                gtk::ScrolledWindow {
+                    set_margin_start: 10,
+                    set_margin_end: 10,
+                    set_vexpand: true,
+
                     gtk::Box {
                         set_orientation: gtk::Orientation::Vertical,
                         set_spacing: 10,
 
                         gtk::Box {
-                            set_spacing: 5,
-                            set_tooltip: "Plotting starts after piece cache sync is complete",
-
-                            gtk::Label {
-                                set_halign: gtk::Align::Start,
-
-                                #[watch]
-                                set_label: &format!(
-                                    "Piece cache sync {:.2}%",
-                                    model.farmer_state.piece_cache_sync_progress
-                                ),
-                            },
-
-                            gtk::Spinner {
-                                start: (),
-                            },
-                        },
-
-                        gtk::ProgressBar {
+                            set_orientation: gtk::Orientation::Vertical,
+                            set_spacing: 10,
                             #[watch]
-                            set_fraction: model.farmer_state.piece_cache_sync_progress as f64 / 100.0,
-                        },
-                    }
-                } else {
-                    gtk::Box {
-                        gtk::Label {
-                            set_halign: gtk::Align::Start,
-                            #[watch]
-                            set_label: &{
-                                if matches!(model.node_state.sync_state, SyncState::Idle) {
-                                    let mut statuses = Vec::new();
-                                    let plotting = model.farmer_state.plotting_state.iter().any(|plotting_state| {
-                                        matches!(plotting_state, PlottingState::Plotting { kind: PlottingKind::Initial, .. })
-                                    });
-                                    let replotting = model.farmer_state.plotting_state.iter().any(|plotting_state| {
-                                        matches!(plotting_state, PlottingState::Plotting { kind: PlottingKind::Replotting, .. })
-                                    });
-                                    let idle = model.farmer_state.plotting_state.iter().any(|plotting_state| {
-                                        matches!(plotting_state, PlottingState::Idle)
-                                    });
-                                    if plotting {
-                                        statuses.push(if statuses.is_empty() {
-                                            "Plotting"
-                                        } else {
-                                            "plotting"
-                                        });
-                                    }
-                                    if matches!(model.node_state.sync_state, SyncState::Idle) && (model.farmer_state.farm_during_initial_plotting || replotting || idle) {
-                                        statuses.push(if statuses.is_empty() {
-                                            "Farming"
-                                        } else {
-                                            "farming"
-                                        });
-                                    }
-                                    if replotting {
-                                        statuses.push(if statuses.is_empty() {
-                                            "Replotting"
-                                        } else {
-                                            "replotting"
-                                        });
-                                    }
+                            set_visible: model.farmer_state.piece_cache_sync_progress < 100.0,
 
-                                    statuses.join(", ")
-                                } else {
-                                    "Waiting for node to sync first".to_string()
-                                }
-                            },
-                        },
-
-                        gtk::Box {
-                            set_halign: gtk::Align::End,
-                            set_hexpand: true,
-
-                            gtk::LinkButton {
-                                remove_css_class: "link",
-                                set_tooltip: "Total account balance and coins farmed since application started, click to see details in Astral",
-                                #[watch]
-                                // TODO: Would be great to have `gemini-3g` in chain spec, but it is
-                                //  not available in there in clean form
-                                set_uri: &format!(
-                                    "https://explorer.subspace.network/#/{}/consensus/accounts/{}",
-                                    model.chain_info.protocol_id.strip_prefix("subspace-").unwrap_or(&model.chain_info.protocol_id),
-                                    model.farmer_state.reward_address
-                                ),
-                                set_use_underline: false,
+                            gtk::Box {
+                                set_spacing: 5,
+                                set_tooltip: "Plotting starts after piece cache sync is complete",
 
                                 gtk::Label {
+                                    set_halign: gtk::Align::Start,
+
                                     #[watch]
-                                    set_label: &{
-                                        let current_balance = model.farmer_state.reward_address_balance;
-                                        let balance_increase = model.farmer_state.reward_address_balance - model.farmer_state.initial_reward_address_balance;
-                                        let current_balance = (current_balance / (SSC / 100)) as f32 / 100.0;
-                                        let balance_increase = (balance_increase / (SSC / 100)) as f32 / 100.0;
-                                        let token_symbol = &model.chain_info.token_symbol;
-
-                                        format!(
-                                            "{current_balance:.2}<span color=\"#3bbf2c\"><sup>+{balance_increase:.2}</sup></span> {token_symbol}"
-                                        )
-                                    },
-                                    set_use_markup: true,
+                                    set_label: &format!(
+                                        "Piece cache sync {:.2}%",
+                                        model.farmer_state.piece_cache_sync_progress
+                                    ),
                                 },
-                            }
-                        },
-                    }
-                },
 
-                #[local_ref]
-                farms_box -> gtk::Box {
-                    set_margin_start: 10,
-                    set_margin_end: 10,
-                    set_orientation: gtk::Orientation::Vertical,
-                    set_spacing: 10,
+                                gtk::Spinner {
+                                    start: (),
+                                },
+                            },
+
+                            gtk::ProgressBar {
+                                #[watch]
+                                set_fraction: model.farmer_state.piece_cache_sync_progress as f64 / 100.0,
+                            },
+                        },
+
+                        #[local_ref]
+                        farms_box -> gtk::Box {
+                            set_orientation: gtk::Orientation::Vertical,
+                            set_spacing: 10,
+                        },
+                    },
                 },
             },
         }
@@ -315,22 +271,26 @@ impl RunningView {
             RunningInput::Initialize {
                 best_block_number,
                 reward_address_balance,
-                initial_plotting_states,
+                initial_farm_states,
                 farm_during_initial_plotting,
                 raw_config,
                 chain_info,
             } => {
-                for (farm_index, (initial_plotting_state, farm)) in initial_plotting_states
+                for (farm_index, (initial_farm_state, farm)) in initial_farm_states
                     .iter()
                     .copied()
                     .zip(raw_config.farms().iter().cloned())
                     .enumerate()
                 {
                     self.farms.insert(
-                        farm_index,
+                        u8::try_from(farm_index).expect(
+                            "More than 256 plots are not supported, this is checked on \
+                            backend; qed",
+                        ),
                         FarmWidgetInit {
-                            initial_plotting_state,
                             farm,
+                            total_sectors: initial_farm_state.total_sectors_count,
+                            plotted_total_sectors: initial_farm_state.plotted_sectors_count,
                             farm_during_initial_plotting,
                         },
                     );
@@ -344,8 +304,6 @@ impl RunningView {
                     initial_reward_address_balance: reward_address_balance,
                     reward_address_balance,
                     reward_address: raw_config.reward_address().to_string(),
-                    plotting_state: initial_plotting_states,
-                    farm_during_initial_plotting,
                     piece_cache_sync_progress: 0.0,
                 };
                 self.chain_info = chain_info;
@@ -411,17 +369,18 @@ impl RunningView {
                 }
             },
             RunningInput::FarmerNotification(farmer_notification) => match farmer_notification {
-                FarmerNotification::PlottingStateUpdate { farm_index, state } => {
-                    self.farms
-                        .send(&farm_index, FarmWidgetInput::PlottingStateUpdate(state));
-
-                    if let Some(plotting_state) =
-                        self.farmer_state.plotting_state.get_mut(farm_index)
-                    {
-                        *plotting_state = state;
-                    } else {
-                        warn!(%farm_index, "Unexpected plotting farm index");
-                    }
+                FarmerNotification::SectorUpdate {
+                    farm_index,
+                    sector_index,
+                    update,
+                } => {
+                    self.farms.send(
+                        &farm_index,
+                        FarmWidgetInput::SectorUpdate {
+                            sector_index,
+                            update,
+                        },
+                    );
                 }
                 FarmerNotification::PieceCacheSyncProgress { progress } => {
                     let old_synced = self.farmer_state.piece_cache_sync_progress == 100.0;

--- a/src/frontend/running.rs
+++ b/src/frontend/running.rs
@@ -284,7 +284,7 @@ impl Component for RunningView {
 
     fn init(
         _init: Self::Init,
-        _root: &Self::Root,
+        _root: Self::Root,
         _sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         let farms = FactoryHashMap::builder()

--- a/src/main.rs
+++ b/src/main.rs
@@ -488,7 +488,7 @@ impl App {
                 raw_config,
                 best_block_number,
                 reward_address_balance,
-                initial_plotting_states,
+                initial_farm_states,
                 farm_during_initial_plotting,
                 chain_info,
             } => {
@@ -497,7 +497,7 @@ impl App {
                 self.running_view.emit(RunningInput::Initialize {
                     best_block_number,
                     reward_address_balance,
-                    initial_plotting_states,
+                    initial_farm_states,
                     farm_during_initial_plotting,
                     raw_config,
                     chain_info,


### PR DESCRIPTION
A few things here:
* Subspace and relm4 updates
* farm summary state (plotting/replotting/farming) is removed as redundant, the same information is now displayed on per-farm level
* Sectors visualization

Sectors visualization is rendering of a grid of squares, one per each sector on per-farm basis. Color and blinking of the farm corresponds to what happens to the sector:
* gray color for sectors that are not plotted yet
* light blue for sectors that are plotted and up to date
* yellow for sectors that are about to expire and are going to be replotted soon
* pink for expired sectors
* slowly blinking sector is being downloaded
* fast blinking red is being encoded
* slowly blinking light blue is being written to disk

Colors are selected to be a intuitive and to work with both light and dark theme reasonably well.

Resolves https://github.com/nazar-pc/space-acres/issues/87