### PR TITLE
Add advanced configuration for P2P port customization

### DIFF
--- a/src/backend/networking.rs
+++ b/src/backend/networking.rs
@@ -60,14 +60,7 @@ impl Default for NetworkOptions {
         Self {
             keypair: Keypair::generate(),
             bootstrap_nodes: vec![],
-            listen_on: vec![
-                "/ip4/0.0.0.0/udp/30433/quic-v1"
-                    .parse()
-                    .expect("Statically correct; qed"),
-                "/ip4/0.0.0.0/tcp/30433"
-                    .parse()
-                    .expect("Statically correct; qed"),
-            ],
+            listen_on: vec![],
             enable_private_ips: false,
             reserved_peers: Vec::new(),
             in_connections: 300,


### PR DESCRIPTION
This is helpful if there is more than 1 Subspace instance on local network and ports are colliding with default configuration.

This is also the beginning of the advanced configuration in Space Acres :scream: 