### PR TITLE
Visual performance indicators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10704,7 +10704,7 @@ dependencies = [
 
 [[package]]
 name = "space-acres"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -2589,7 +2589,7 @@ dependencies = [
 [[package]]
 name = "domain-block-preprocessor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6753,7 +6753,7 @@ dependencies = [
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6827,7 +6827,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -6851,7 +6851,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6870,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6884,7 +6884,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6896,7 +6896,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6909,7 +6909,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6967,7 +6967,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7023,7 +7023,7 @@ dependencies = [
 [[package]]
 name = "pallet-transporter"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -8661,7 +8661,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "async-trait",
  "futures",
@@ -8701,7 +8701,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -9018,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "sc-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "atomic",
  "core_affinity",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-block-relay"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -10074,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "async-trait",
  "log",
@@ -10189,7 +10189,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -10198,7 +10198,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "blake2",
  "domain-runtime-primitives",
@@ -10229,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "sp-domains-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "domain-block-preprocessor",
  "domain-runtime-primitives",
@@ -10261,7 +10261,7 @@ dependencies = [
 [[package]]
 name = "sp-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10353,7 +10353,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "frame-support",
  "hash-db",
@@ -10383,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -10910,7 +10910,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "parity-scale-codec",
  "rayon",
@@ -10923,7 +10923,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "blake3",
  "derive_more",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "subspace-erasure-coding"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "kzg",
  "rust-kzg-blst",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "anyhow",
  "async-lock 2.8.0",
@@ -11014,7 +11014,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "async-lock 2.8.0",
  "async-trait",
@@ -11044,7 +11044,7 @@ dependencies = [
 [[package]]
 name = "subspace-metrics"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "actix-web",
  "parking_lot 0.12.1",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "actix-web",
  "async-mutex",
@@ -11095,7 +11095,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-space"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "chacha20",
  "derive_more",
@@ -11108,7 +11108,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "aes 0.8.3",
  "subspace-core-primitives",
@@ -11118,7 +11118,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "hex",
  "serde",
@@ -11130,7 +11130,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -11182,7 +11182,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "pallet-transaction-payment",
  "serde",
@@ -11195,7 +11195,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "async-trait",
  "atomic",
@@ -11265,7 +11265,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=b3dac2c718f83e7c4bdf46b7107f43205e05d9cd#b3dac2c718f83e7c4bdf46b7107f43205e05d9cd"
+source = "git+https://github.com/subspace/subspace?rev=b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3#b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9849,6 +9849,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_moving_average"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a09d361a867b34a1feb1de0bddf0fd7dd53e274c47c9cc7091ebfe3e345a382"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10735,6 +10744,7 @@ dependencies = [
  "semver 1.0.21",
  "serde",
  "serde_json",
+ "simple_moving_average",
  "sp-consensus-subspace",
  "sp-core",
  "sp-domains-fraud-proof",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "space-acres"
 description = "Space Acres is an opinionated unofficial GUI application for farming on Subspace Network"
 license = "0BSD"
-version = "0.0.20"
+version = "0.0.21"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 repository = "https://github.com/nazar-pc/space-acres"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,24 +64,24 @@ sc-informant = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b
 sc-network = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
 sc-service = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
 sc-storage-monitor = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
-sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "b3dac2c718f83e7c4bdf46b7107f43205e05d9cd" }
+sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = "b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3" }
 semver = "1.0.21"
 serde = { version = "1.0.194", features = ["derive"]}
 serde_json = "1.0.111"
 sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
-sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "b3dac2c718f83e7c4bdf46b7107f43205e05d9cd" }
-sp-domains-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "b3dac2c718f83e7c4bdf46b7107f43205e05d9cd" }
+sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3" }
+sp-domains-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3" }
 sp-runtime = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
-subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "b3dac2c718f83e7c4bdf46b7107f43205e05d9cd" }
-subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "b3dac2c718f83e7c4bdf46b7107f43205e05d9cd" }
-subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "b3dac2c718f83e7c4bdf46b7107f43205e05d9cd", default-features = false }
-subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "b3dac2c718f83e7c4bdf46b7107f43205e05d9cd" }
-subspace-networking = { git = "https://github.com/subspace/subspace", rev = "b3dac2c718f83e7c4bdf46b7107f43205e05d9cd" }
-subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "b3dac2c718f83e7c4bdf46b7107f43205e05d9cd" }
-subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "b3dac2c718f83e7c4bdf46b7107f43205e05d9cd" }
-subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "b3dac2c718f83e7c4bdf46b7107f43205e05d9cd" }
-subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "b3dac2c718f83e7c4bdf46b7107f43205e05d9cd" }
-subspace-service = { git = "https://github.com/subspace/subspace", rev = "b3dac2c718f83e7c4bdf46b7107f43205e05d9cd" }
+subspace-core-primitives = { git = "https://github.com/subspace/subspace", rev = "b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3" }
+subspace-erasure-coding = { git = "https://github.com/subspace/subspace", rev = "b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3" }
+subspace-farmer = { git = "https://github.com/subspace/subspace", rev = "b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3", default-features = false }
+subspace-farmer-components = { git = "https://github.com/subspace/subspace", rev = "b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3" }
+subspace-networking = { git = "https://github.com/subspace/subspace", rev = "b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3" }
+subspace-proof-of-space = { git = "https://github.com/subspace/subspace", rev = "b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3" }
+subspace-rpc-primitives = { git = "https://github.com/subspace/subspace", rev = "b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3" }
+subspace-runtime = { git = "https://github.com/subspace/subspace", rev = "b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3" }
+subspace-runtime-primitives = { git = "https://github.com/subspace/subspace", rev = "b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3" }
+subspace-service = { git = "https://github.com/subspace/subspace", rev = "b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3" }
 supports-color = "2.0.0"
 thiserror = "1.0.50"
 tokio = { version = "1.34.0", features = ["fs", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ pallet-balances = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63
 parity-scale-codec = "3.6.9"
 parking_lot = "0.12.1"
 relm4 = { version = "0.7.0-beta.2", git = "https://github.com/Relm4/Relm4", rev = "e189eee06b887470e0fd65cbaf6d7c0161bed5ea" }
-relm4-icons = { version = "0.7.0-alpha.2", features = ["checkmark", "cross", "menu-large", "size-horizontally", "ssd", "wallet2"] }
+relm4-icons = { version = "0.7.0-alpha.2", features = ["checkmark", "cross", "menu-large", "processor", "puzzle-piece", "size-horizontally", "ssd", "wallet2"] }
 relm4-components = { version = "0.7.0-beta.2", git = "https://github.com/Relm4/Relm4", rev = "e189eee06b887470e0fd65cbaf6d7c0161bed5ea", default-features = false }
 reqwest = { version = "0.11.23", default-features = false, features = ["json", "rustls-tls"] }
 sc-client-api = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
@@ -68,6 +68,7 @@ sc-subspace-chain-specs = { git = "https://github.com/subspace/subspace", rev = 
 semver = "1.0.21"
 serde = { version = "1.0.194", features = ["derive"]}
 serde_json = "1.0.111"
+simple_moving_average = "1.0.1"
 sp-core = { git = "https://github.com/subspace/polkadot-sdk", rev = "c63a8b28a9fd26d42116b0dcef1f2a5cefb9cd1c", default-features = false }
 sp-consensus-subspace = { git = "https://github.com/subspace/subspace", rev = "b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3" }
 sp-domains-fraud-proof = { git = "https://github.com/subspace/subspace", rev = "b36bb3d1f2ca04f8a2d4f1e539718e1a21c6c9d3" }

--- a/res/app.css
+++ b/res/app.css
@@ -27,6 +27,11 @@ progressbar progress {
     background-color: #ffA400;
 }
 
+.auditing-performance > trough >  block.low,
+.proving-performance > trough >  block.low {
+    background-color: #ffA400;
+}
+
 farm-sectors > child {
     padding: 0;
 }

--- a/src/backend/farmer.rs
+++ b/src/backend/farmer.rs
@@ -19,6 +19,7 @@ use subspace_core_primitives::crypto::kzg::{embedded_kzg_settings, Kzg};
 use subspace_core_primitives::{PublicKey, Record, SectorIndex};
 use subspace_erasure_coding::ErasureCoding;
 use subspace_farmer::piece_cache::{CacheWorker, PieceCache};
+use subspace_farmer::single_disk_farm::farming::FarmingNotification;
 use subspace_farmer::single_disk_farm::{
     SectorPlottingDetails, SectorUpdate, SingleDiskFarm, SingleDiskFarmError, SingleDiskFarmOptions,
 };
@@ -52,6 +53,10 @@ pub enum FarmerNotification {
         farm_index: u8,
         sector_index: SectorIndex,
         update: SectorUpdate,
+    },
+    FarmingNotification {
+        farm_index: u8,
+        notification: FarmingNotification,
     },
     PieceCacheSyncProgress {
         /// Progress so far in %
@@ -420,15 +425,30 @@ pub(super) async fn create_farmer(farmer_options: FarmerOptions) -> anyhow::Resu
             );
             let readers_and_pieces = Arc::clone(&readers_and_pieces);
             let span = info_span!("farm", %disk_farm_index);
-            let notifications = Arc::clone(&notifications);
 
             single_disk_farm
-                .on_sector_update(Arc::new(move |(sector_index, sector_update)| {
-                    notifications.call_simple(&FarmerNotification::SectorUpdate {
-                        farm_index: disk_farm_index,
-                        sector_index: *sector_index,
-                        update: sector_update.clone(),
-                    });
+                .on_sector_update(Arc::new({
+                    let notifications = Arc::clone(&notifications);
+
+                    move |(sector_index, sector_update)| {
+                        notifications.call_simple(&FarmerNotification::SectorUpdate {
+                            farm_index: disk_farm_index,
+                            sector_index: *sector_index,
+                            update: sector_update.clone(),
+                        });
+                    }
+                }))
+                .detach();
+            single_disk_farm
+                .on_farming_notification(Arc::new({
+                    let notifications = Arc::clone(&notifications);
+
+                    move |notification| {
+                        notifications.call_simple(&FarmerNotification::FarmingNotification {
+                            farm_index: disk_farm_index,
+                            notification: notification.clone(),
+                        });
+                    }
                 }))
                 .detach();
 

--- a/src/backend/node.rs
+++ b/src/backend/node.rs
@@ -77,8 +77,6 @@ pub enum SyncState {
     Syncing {
         kind: SyncKind,
         target: BlockNumber,
-        /// Sync speed in blocks/s
-        speed: Option<f32>,
     },
     Idle,
 }
@@ -183,8 +181,6 @@ impl ConsensusNode {
                                 _ => SyncKind::Regular,
                             },
                             target: sync_status.best_seen_block.unwrap_or_default(),
-                            // TODO: Sync speed
-                            speed: None,
                         }
                     } else if sync_status.num_connected_peers > 0 {
                         SyncState::Idle

--- a/src/frontend/running.rs
+++ b/src/frontend/running.rs
@@ -10,8 +10,40 @@ use crate::frontend::running::node::{NodeInput, NodeView};
 use gtk::prelude::*;
 use relm4::factory::FactoryHashMap;
 use relm4::prelude::*;
+use simple_moving_average::SingleSumSMA;
+use std::fmt;
+use std::ops::{Deref, DerefMut};
 use subspace_core_primitives::BlockNumber;
 use subspace_runtime_primitives::{Balance, SSC};
+
+// TODO: Remove wrapper once https://github.com/oskargustafsson/moving_average/issues/2 is resolved
+struct SmaWrapper<Sample, Divisor, const WINDOW_SIZE: usize>(
+    SingleSumSMA<Sample, Divisor, WINDOW_SIZE>,
+);
+
+impl<Sample, Divisor, const WINDOW_SIZE: usize> fmt::Debug
+    for SmaWrapper<Sample, Divisor, WINDOW_SIZE>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SingleSumSMA").finish()
+    }
+}
+
+impl<Sample, Divisor, const WINDOW_SIZE: usize> Deref for SmaWrapper<Sample, Divisor, WINDOW_SIZE> {
+    type Target = SingleSumSMA<Sample, Divisor, WINDOW_SIZE>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<Sample, Divisor, const WINDOW_SIZE: usize> DerefMut
+    for SmaWrapper<Sample, Divisor, WINDOW_SIZE>
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
 #[derive(Debug)]
 pub enum RunningInput {
@@ -282,6 +314,15 @@ impl RunningView {
                             sector_index,
                             update,
                         },
+                    );
+                }
+                FarmerNotification::FarmingNotification {
+                    farm_index,
+                    notification,
+                } => {
+                    self.farms.send(
+                        &farm_index,
+                        FarmWidgetInput::FarmingNotification(notification),
                     );
                 }
                 FarmerNotification::PieceCacheSyncProgress { progress } => {

--- a/src/frontend/running/farm.rs
+++ b/src/frontend/running/farm.rs
@@ -1,9 +1,14 @@
 use crate::backend::config::Farm;
+use crate::frontend::running::SmaWrapper;
 use gtk::prelude::*;
 use relm4::prelude::*;
+use relm4_icons::icon_name;
+use simple_moving_average::{SingleSumSMA, SMA};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::time::Duration;
 use subspace_core_primitives::SectorIndex;
+use subspace_farmer::single_disk_farm::farming::FarmingNotification;
 use subspace_farmer::single_disk_farm::{
     SectorExpirationDetails, SectorPlottingDetails, SectorUpdate,
 };
@@ -13,6 +18,18 @@ use subspace_farmer::single_disk_farm::{
 const MIN_SECTORS_PER_ROW: u32 = 108;
 /// Effectively no limit
 const MAX_SECTORS_PER_ROW: u32 = 100_000;
+/// Number of samples over which to track auditing time, 1 minute in slots
+const AUDITING_TIME_TRACKING_WINDOW: usize = 60;
+/// One second to audit
+const MAX_AUDITING_TIME: Duration = Duration::from_secs(1);
+/// 500ms auditing time is excellent, anything larger will result in auditing performance indicator decrease
+const EXCELLENT_AUDITING_TIME: Duration = Duration::from_millis(500);
+/// Number of samples over which to track proving time
+const PROVING_TIME_TRACKING_WINDOW: usize = 10;
+/// TODO: Ideally this would come from node's chain constants, but this will do for now
+const BLOCK_AUTHORING_DELAY: Duration = Duration::from_secs(4);
+/// 1800ms proving time is excellent, anything larger will result in proving performance indicator decrease
+const EXCELLENT_PROVING_TIME: Duration = Duration::from_millis(1800);
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 enum PlottingKind {
@@ -69,6 +86,7 @@ pub(super) enum FarmWidgetInput {
         sector_index: SectorIndex,
         update: SectorUpdate,
     },
+    FarmingNotification(FarmingNotification),
     PieceCacheSynced(bool),
     NodeSynced(bool),
 }
@@ -77,6 +95,8 @@ pub(super) enum FarmWidgetInput {
 pub(super) struct FarmWidget {
     path: PathBuf,
     size: String,
+    auditing_time: SmaWrapper<Duration, u32, AUDITING_TIME_TRACKING_WINDOW>,
+    proving_time: SmaWrapper<Duration, u32, PROVING_TIME_TRACKING_WINDOW>,
     last_sector_plotted: Option<SectorIndex>,
     plotting_state: PlottingState,
     is_piece_cache_synced: bool,
@@ -101,9 +121,72 @@ impl FactoryComponent for FarmWidget {
             set_orientation: gtk::Orientation::Vertical,
             set_spacing: 10,
 
-            gtk::Label {
-                set_halign: gtk::Align::Start,
-                set_label: &format!("{} [{}]:", self.path.display(), self.size),
+            gtk::Box {
+                gtk::Label {
+                    set_halign: gtk::Align::Start,
+                    set_label: &format!("{} [{}]:", self.path.display(), self.size),
+                },
+
+                gtk::Box {
+                    set_halign: gtk::Align::End,
+                    set_hexpand: true,
+
+                    gtk::Box {
+                        set_spacing: 10,
+                        #[watch]
+                        set_tooltip: &format!(
+                            "Auditing performance: average time {:.2}s, time limit {:.2}s",
+                            self.auditing_time.get_average().as_secs_f32(),
+                            MAX_AUDITING_TIME.as_secs_f32()
+                        ),
+                        #[watch]
+                        set_visible: self.auditing_time.get_num_samples() > 0,
+
+                        gtk::Image {
+                            set_icon_name: Some(icon_name::PUZZLE_PIECE),
+                        },
+
+                        gtk::LevelBar {
+                            add_css_class: "auditing-performance",
+                            #[watch]
+                            set_value: {
+                                let average_time = self.auditing_time.get_average();
+                                let slot_time_fraction_remaining = 1.0 - average_time.as_secs_f64() / MAX_AUDITING_TIME.as_secs_f64();
+                                let excellent_time_fraction_remaining = 1.0 - EXCELLENT_AUDITING_TIME.as_secs_f64() / MAX_AUDITING_TIME.as_secs_f64();
+                                (slot_time_fraction_remaining / excellent_time_fraction_remaining).clamp(0.0, 1.0)
+                            },
+                            set_width_request: 70,
+                        },
+                    },
+
+                    gtk::Box {
+                        set_spacing: 10,
+                        #[watch]
+                        set_tooltip: &format!(
+                            "Proving performance: average time {:.2}s, time limit {:.2}s",
+                            self.proving_time.get_average().as_secs_f32(),
+                            BLOCK_AUTHORING_DELAY.as_secs_f32()
+                        ),
+                        #[watch]
+                        set_visible: self.proving_time.get_num_samples() > 0,
+
+                        gtk::Image {
+                            set_icon_name: Some(icon_name::PROCESSOR),
+                        },
+
+                        gtk::LevelBar {
+                            add_css_class: "proving-performance",
+                            #[watch]
+                            set_value: {
+                                let average_time = self.proving_time.get_average();
+                                let slot_time_fraction_remaining = 1.0 - average_time.as_secs_f64() / BLOCK_AUTHORING_DELAY.as_secs_f64();
+                                let excellent_time_fraction_remaining = 1.0 - EXCELLENT_PROVING_TIME.as_secs_f64() / BLOCK_AUTHORING_DELAY.as_secs_f64();
+                                (slot_time_fraction_remaining / excellent_time_fraction_remaining).clamp(0.0, 1.0)
+                            },
+                            set_width_request: 70,
+                        },
+                    },
+                },
             },
 
             #[transition = "SlideUpDown"]
@@ -221,6 +304,8 @@ impl FactoryComponent for FarmWidget {
         Self {
             path: init.farm.path,
             size: init.farm.size,
+            auditing_time: SmaWrapper(SingleSumSMA::from_zero(Duration::ZERO)),
+            proving_time: SmaWrapper(SingleSumSMA::from_zero(Duration::ZERO)),
             last_sector_plotted: None,
             plotting_state: PlottingState::Idle,
             is_piece_cache_synced: false,
@@ -303,6 +388,14 @@ impl FarmWidget {
                         self.update_sector_state(sector_index, SectorState::Expired);
                     }
                 },
+            },
+            FarmWidgetInput::FarmingNotification(notification) => match notification {
+                FarmingNotification::Auditing(auditing_details) => {
+                    self.auditing_time.add_sample(auditing_details.time);
+                }
+                FarmingNotification::Proving(proving_details) => {
+                    self.proving_time.add_sample(proving_details.time);
+                }
             },
             FarmWidgetInput::PieceCacheSynced(synced) => {
                 self.is_piece_cache_synced = synced;

--- a/src/frontend/running/farm.rs
+++ b/src/frontend/running/farm.rs
@@ -278,7 +278,7 @@ impl FarmWidget {
                     SectorPlottingDetails::Writing => {
                         self.update_sector_state(sector_index, SectorState::Writing);
                     }
-                    SectorPlottingDetails::Wrote(_) => {
+                    SectorPlottingDetails::Written(_) => {
                         self.remove_sector_state(sector_index, SectorState::Writing);
                     }
                     SectorPlottingDetails::Finished { .. } => {


### PR DESCRIPTION
With these changes a few things are added:
* Auditing and proving performance indicators are shown with reasonable targets set, showing when performance is not acceptable (skipped proving is not shown yet though)
* Node sync speed is shown with expected remaining time
* Plotting/replotting speed is shown as both minutes per sector and sectors per hour

Resolves https://github.com/nazar-pc/space-acres/issues/77, resolves https://github.com/nazar-pc/space-acres/issues/34, resolves https://github.com/nazar-pc/space-acres/issues/12

Also with Subspace update NUMA enabling in BIOS is no longer necessary as farmer will check L3 cache topology instead.